### PR TITLE
Fix bootstrap crash in index config page

### DIFF
--- a/src/templates/index_search_config.html
+++ b/src/templates/index_search_config.html
@@ -1,4 +1,17 @@
-{% from 'bootstrap5/form.html' import render_field %}
+{% macro render_field(field) %}
+    <div class="form-control">
+        {% if field.name != 'submit' %}
+            {{ field.label }}
+        {% endif %}
+
+        {{ field(**kwargs)|safe }}
+        {% if field.errors %}
+            {% for error in field.errors %}
+                {{ error }}
+            {% endfor %}
+        {% endif %}
+    </div>
+{% endmacro %}
 
 {% extends "base.html" %}
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -39,7 +39,8 @@ async def render_controller(template: str | Template, **kwargs):
         return await render_template(template.name, **kwargs)
 
     if isinstance(template, Template):
-        return await template.render_async(**kwargs)
+        return template.render(**kwargs)
+        # return await template.render_async(**kwargs) # not sure why quart's jinja2 env is setup like this...
 
     raise ValueError(CONSTS.TESTING, type(template), template)
 


### PR DESCRIPTION
- Loading the index config page (create/delete index, index board) gui was crashing
   - Because the environment this template came from doesn't have bootstrap patching it
- The macro should ideally be put into `macros.html`
   - That page should be behind admin panel anyways, macro import penalty won't matter unlike search
   - But I didn't do it because I'm not sure what the `"form-control"` class does, if its generic enough or not