### PR TITLE
perf_counter wrapper class + examples

### DIFF
--- a/src/blueprint_app.py
+++ b/src/blueprint_app.py
@@ -24,7 +24,8 @@ from utils import (
     get_title,
     render_controller,
     validate_board_shortname,
-    validate_threads
+    validate_threads,
+    Perf,
 )
 
 blueprint_app = Blueprint("blueprint_app", __name__)
@@ -226,22 +227,19 @@ async def v_thread(board_shortname: str, thread_id: int):
     """
     validate_board_shortname(board_shortname)
 
-    i = perf_counter()
+    p = Perf()
     # use the existing json app function to grab the data
     thread_dict, post_2_quotelinks = await convert_thread(board_shortname, thread_id)
-    f = perf_counter()
-    print(f'queries:  {f-i:.4f}')
+    p.check('queries')
 
-    i = perf_counter()
     validate_threads(thread_dict['posts'])
-    f = perf_counter()
-    print(f'validate: {f-i:.4f}')
+    p.check('validate')
 
     posts_t = get_posts_t(thread_dict['posts'], post_2_quotelinks=post_2_quotelinks)
+    p.check('posts_t')
 
     title = f"/{board_shortname}/ #{thread_id}"
 
-    i = perf_counter()
     render = await render_controller(
         template_thread,
         posts_t=posts_t,
@@ -250,8 +248,7 @@ async def v_thread(board_shortname: str, thread_id: int):
         title=title,
         tab_title=title,
     )
-    f = perf_counter()
-    print(f'rendered: {f-i:.4f}')
+    p.check('rendered')
     return render
 
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,3 +1,4 @@
+from time import perf_counter
 import re
 from html import escape
 
@@ -72,3 +73,18 @@ def highlight_search_results(form, posts):
                 posts['posts'][i][asagi_name] = post[asagi_name][:j] + highlight_str + post[asagi_name][j + len(escaped_field) :]
 
     return posts
+
+
+class Perf:
+    __slots__ = ('previous', 'total')
+
+    def __init__(self):
+        self.previous = perf_counter()
+        self.total = 0
+
+    def check(self, name: str=""):
+        now = perf_counter()
+        elapsed = now - self.previous
+        self.previous = now
+        self.total += elapsed
+        print(f'{elapsed:.4f} {self.total:.4f} {name}')


### PR DESCRIPTION
- Reusable ergonomic class for tracking perf issues across endpoints
- Keeps running total
- uses `check()`, short for checkpoint
- eventually will
    - migrate from print to logging.trace
    - be moved to its own file

example:
- output before
```
queries:  0.0331
validate: 0.0000
rendered: 0.0114
queries:  0.0246
validate: 0.0000
rendered: 0.0077
```
- output after
```
0.0108 0.0108 queries
0.0002 0.0110 validate
0.0248 0.0358 posts_t
0.0021 0.0379 rendered
0.0109 0.0109 queries
0.0001 0.0110 validate
0.0248 0.0358 posts_t
0.0019 0.0377 rendered
```