### PR TITLE
remove commit when deleting lnx index

### DIFF
--- a/src/search/providers/lnx.py
+++ b/src/search/providers/lnx.py
@@ -62,7 +62,6 @@ class LnxSearch(BaseSearch):
     async def _index_delete(self, index: str):
         url = self._get_index_url(index)
         resp = await self.client.delete(url)
-        await self._commit_write(index)
         # return loads(await resp.read())
 
     async def _index_ready(self, index: str):


### PR DESCRIPTION
There is no index to "commit" changes to anymore, deleted indexes are instantly unavailable. The writer threads will do their cleanups asynchroniously.