### PR TITLE
Db refactor 2 (Safe)

### DIFF
--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -7,15 +7,11 @@ from . import db_mysql, db_sqlite
 from .db_interface import DatabaseInterface
 
 
-def get_database_instance(app_context=True) -> DatabaseInterface:
+def get_database_instance() -> DatabaseInterface:
     db_module = _get_db_module(CONSTS.db_type)
-    if app_context:
-        if not hasattr(get_database_instance, 'db_app_context'):
-            get_database_instance.db_app_context = db_module.DatabaseAppContext()
-        return get_database_instance.db_app_context
-    if not hasattr(get_database_instance, 'db'):
-        get_database_instance.db = db_module.Database()
-    return get_database_instance.db
+    if not hasattr(get_database_instance, 'db_app_context'):
+        get_database_instance.db_app_context = db_module.DatabaseAppContext()
+    return get_database_instance.db_app_context
 
 
 def _get_db_module(db_type: DbType):

--- a/src/db/db_postgresql.py
+++ b/src/db/db_postgresql.py
@@ -1,0 +1,65 @@
+import asyncpg
+from quart import current_app
+
+from configs import CONSTS
+
+from .db_interface import DatabaseInterface
+
+
+class PostgreSQLDatabaseAppContext(DatabaseInterface):
+    async def connect(self):
+        current_app.pool = await _get_pool(store=False)
+        print('Postgresql pool open')
+
+    async def query_execute(self, sql: str, params=None, fetchone=False, commit=False):
+        async with current_app.pool.acquire() as conn:
+            if CONSTS.sql_echo:
+                print('::SQL::', sql)
+
+            await conn.execute(sql, params)
+
+            if commit:
+                return conn.commit()
+
+            if fetchone:
+                return await conn.fetchone()
+            return await conn.fetchall()
+
+    async def disconnect(self):
+        await current_app.pool.close()
+
+
+# Functions below are for doing Tuple queries, which are faster fetching Dict results
+async def _get_pool(store=True):
+    # we apply an attribute on this function to avoid polluting the module's namespace
+    if not hasattr(_get_pool, 'pool') or not store:
+        pool = await asyncpg.create_pool(
+            host=CONSTS.db_host,
+            port=CONSTS.db_port,
+            user=CONSTS.db_user,
+            password=CONSTS.db_password,
+            database=CONSTS.db_database,
+            min_size=CONSTS.db_min_connections,
+            max_size=CONSTS.db_max_connections,
+        )
+        if not store:
+            return pool
+        _get_pool.pool = pool
+    return _get_pool.pool
+
+
+async def _run_query_fast(query: str, params: tuple=None):
+    pool = await _get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(query, params)
+        return await conn.fetchall()
+
+
+async def _close_pool():
+    if not hasattr(_get_pool, 'pool'):
+        return
+    await _get_pool.pool.close()
+    delattr(_get_pool, 'pool')
+
+
+DatabaseAppContext = PostgreSQLDatabaseAppContext

--- a/src/db/db_sqlite.py
+++ b/src/db/db_sqlite.py
@@ -21,7 +21,7 @@ class SQLiteDatabaseAppContext(DatabaseInterface):
     async def query_execute(self, sql, params=None, fetchone=False, commit=False):
         sql = patch_query(sql)
 
-        if CONSTS.SQLALCHEMY_ECHO:
+        if CONSTS.sql_echo:
             print(sql)
             print(params)
 

--- a/src/db/db_sqlite.py
+++ b/src/db/db_sqlite.py
@@ -10,15 +10,14 @@ from .db_interface import DatabaseInterface, row_factory
 
 class SQLiteDatabaseAppContext(DatabaseInterface):
     async def connect(self):
-        print('Creating database pool, started.')
         current_app.pool = await aiosqlite.connect(CONSTS.db_path)
         current_app.pool.row_factory = row_factory
-        print('Creating database pool, completed.')
+        print('Sqlite pool open')
 
     async def disconnect(self):
         await current_app.pool.close()
 
-    async def query_execute(self, sql, params=None, fetchone=False, commit=False):
+    async def query_execute(self, sql: str, params=None, fetchone=False, commit=False):
         sql = patch_query(sql)
 
         if CONSTS.sql_echo:
@@ -37,48 +36,18 @@ class SQLiteDatabaseAppContext(DatabaseInterface):
             return await cursor.fetchall()
 
 
-class SQLiteDatabase(DatabaseInterface):
-    def __init__(self):
-        self.pool = None
-
-    async def connect(self):
-        print('Creating database pool, started.')
-        self.pool = await aiosqlite.connect(CONSTS.db_path)
-        self.pool.row_factory = row_factory
-        print('Creating database pool, completed.')
-
-    async def disconnect(self):
-        await self.pool.close()
-
-    async def query_execute(self, sql, params=None, fetchone=False, commit=False):
-        sql = patch_query(sql)
-
-        if CONSTS.SQLALCHEMY_ECHO:
-            print(sql)
-            print(params)
-
-        async with self.pool.execute(sql, params) as cursor:
-
-            if commit:
-                self.pool.commit()
-                return
-
-            if fetchone:
-                return await cursor.fetchone()
-
-            return await cursor.fetchall()
-
-
 # Functions below are for doing Tuple queries, which are faster fetching Dict results
 
-
-async def _get_pool():
+async def _get_pool(store=True):
     # we apply an attribute on this function to avoid polluting the module's namespace
-    if not hasattr(_get_pool, 'pool'):
-        _get_pool.pool = await aiosqlite.connect(
+    if not hasattr(_get_pool, 'pool') or not store:
+        pool = await aiosqlite.connect(
             CONSTS.db_path,
             autocommit=True,
         )
+        if not store:
+            return pool
+        _get_pool.pool = pool
     return _get_pool.pool
 
 
@@ -109,5 +78,4 @@ def patch_query(query: str) -> str:
     return re_mysql_bind_to_sqlite_bind.sub(r':\1', query).replace('`', '').replace('%s', '?').replace("strftime('?', ", "strftime('%s', ")
 
 
-Database = SQLiteDatabase
 DatabaseAppContext = SQLiteDatabaseAppContext

--- a/src/rename_to_configs.py
+++ b/src/rename_to_configs.py
@@ -81,7 +81,7 @@ class CONSTS(NamedTuple):
     )
 
     MAX_CONTENT_LENGTH = 1 * 1024 * 1024  # 1 MB upload capacity
-    SQLALCHEMY_ECHO = False
+    sql_echo = False
 
     root_dir = os.path.dirname(__file__)
     chdir_to_root = False


### PR DESCRIPTION
Safe preliminary changes to the `db` package

- init postgresql
	- tentatively add support
		- no DbType.postgresql yet, intentionally
	- Uses immutable named tuples as default row type (Record)
- Eliminate DB instances not attached to `app_context`
	- We never used them
- sql_echo
	- rename flag from `SQLALCHEMY_ECHO` to `sql_echo`
	- we don't use sqlalchemy
- remove opening pool message
        - will crash in obvious manner if pool fails to open
        - too many messages when spinning up process pools for loading
- `get_pool()`
	- flag to determine if the pool should be stored in the function or managed elsewhere
		- this might not be needed in the future
	- Not applied to sqlite for safety reasons (sqlite is used to develop moderation currently)
